### PR TITLE
Create docker image and option to run with compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Use a lightweight base image with Python
+FROM python:3.11-slim
+
+# Set working directory
+WORKDIR /app
+
+# Install runtime dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the script
+COPY qB-QueueMETA.py .
+
+# Entrypoint to allow passing args via `command:` in Compose
+ENTRYPOINT ["python", "qB-QueueMETA.py"]

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,16 @@
+services:
+  qb-queuemeta:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command:
+      - --host
+      - 192.168.2.10:8080
+      - --username
+      - admin
+      - --password
+      - adminadmin
+      - --interval
+      - "60"
+      - --verbose
+    restart: unless-stopped


### PR DESCRIPTION
closes #3

the compose file is not ideal as the end user will need to build the image themselves, however it works. The owner of the repo would need to upload the image to a registry.

if this is outside of your scope let me know, and I will end up hosting it, however I don't want to take credit for this project you have made


This is an example of how you could upload the image to a registry
```bash
# GitHub
echo $GITHUB_TOKEN | docker login ghcr.io -u <your-username> --password-stdin

# Docker Hub
docker login
```

**3. Push the image:**

```bash
docker push ghcr.io/<your-username>/qb-queuemeta:latest
```